### PR TITLE
fix: public IP to EIP

### DIFF
--- a/examples/base_pse/README.md
+++ b/examples/base_pse/README.md
@@ -48,7 +48,7 @@ From base_pse directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.4.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.6.0 |
+| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.7.0 |
 
 ## Providers
 

--- a/examples/base_pse/outputs.tf
+++ b/examples/base_pse/outputs.tf
@@ -23,14 +23,17 @@ ${join("\n", distinct(module.pse_vm.availability_zone))}
 All PSE Instance IDs:
 ${join("\n", module.pse_vm.id)}
 
-All PSE Public IPs:
-${join("\n", module.pse_vm.public_ip)}
+All PSE Elastic IP IDs (if EIPs created):
+${join("\n", module.pse_vm.eip_id)}
+
+All PSE Public IPs (if EIPs created):
+${join("\n", module.pse_vm.eip_public_ip)}
+
+All NAT GW IPs (if no EIPs created):
+${join("\n", module.network.nat_gateway_ips)}
 
 All PSE IAM Role ARNs:
 ${join("\n", module.pse_iam.iam_instance_profile_arn)}
-
-All NAT GW IPs:
-${join("\n", module.network.nat_gateway_ips)}
 
 TB
 }

--- a/examples/base_pse/terraform.tfvars
+++ b/examples/base_pse/terraform.tfvars
@@ -35,7 +35,7 @@
 #pse_group_upgrade_time_in_secs     = "66600"
 #pse_group_override_version_profile = true
 #pse_group_version_profile_id       = "2"
-#pse_is_public                      = "FALSE"
+#pse_is_public                      = false
 #zpa_trusted_network_name           = "Corporate-Network (zscalertwo.net)"   ### this variable is optional. leave commented out if not used  
 
 

--- a/examples/base_pse/terraform.tfvars
+++ b/examples/base_pse/terraform.tfvars
@@ -89,12 +89,9 @@
 #pse_count                                       = 2
 
 ## 10. Enable/Disable public IP addresses on Service Edge instances. Default is false. Setting this to true will result in the following: 
-##    Dynamic Public IP address on the Service Edge VM Instance will be enabled; 
+##    Elastic IP address resource creation and assigned per Service Edge instance; 
 ##    No EIP or NAT Gateway resources will be created; 
 ##    The Service Edge Route Table default route next-hop will be set as the IGW
-
-##    Note: Service Edge has no external inbound network dependencies, so the recommendation is to leave this set to false and utilize a NAT Gateway
-##    for internet egress. Only enable this if you are certain you really want it for you environment.
 
 #associate_public_ip_address                    = true
 

--- a/examples/base_pse/versions.tf
+++ b/examples/base_pse/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
     zpa = {
       source  = "zscaler/zpa"
-      version = "~> 2.6.0"
+      version = "~> 2.7.0"
     }
   }
 

--- a/examples/base_pse_asg/README.md
+++ b/examples/base_pse_asg/README.md
@@ -47,7 +47,7 @@ From base_pse_asg directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.4.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.6.0 |
+| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.7.0 |
 
 ## Providers
 

--- a/examples/base_pse_asg/terraform.tfvars
+++ b/examples/base_pse_asg/terraform.tfvars
@@ -35,7 +35,7 @@
 #pse_group_upgrade_time_in_secs     = "66600"
 #pse_group_override_version_profile = true
 #pse_group_version_profile_id       = "2"
-#pse_is_public                      = "FALSE"
+#pse_is_public                      = false
 #zpa_trusted_network_name           = "Corporate-Network (zscalertwo.net)"   ### this variable is optional. leave commented out if not used  
 
 

--- a/examples/base_pse_asg/versions.tf
+++ b/examples/base_pse_asg/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
     zpa = {
       source  = "zscaler/zpa"
-      version = "~> 2.6.0"
+      version = "~> 2.7.0"
     }
   }
 

--- a/examples/pse/README.md
+++ b/examples/pse/README.md
@@ -47,7 +47,7 @@ From pse directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.4.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.6.0 |
+| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.7.0 |
 
 ## Providers
 

--- a/examples/pse/outputs.tf
+++ b/examples/pse/outputs.tf
@@ -15,10 +15,13 @@ ${join("\n", module.pse_vm.id)}
 All PSE Private IPs:
 ${join("\n", module.pse_vm.private_ip)}
 
-All PSE Public IPs:
-${join("\n", module.pse_vm.public_ip)}
+All PSE Elastic IP IDs (if EIPs created):
+${join("\n", module.pse_vm.eip_id)}
 
-All NAT GW IPs:
+All PSE Public IPs (if EIPs created):
+${join("\n", module.pse_vm.eip_public_ip)}
+
+All NAT GW IPs (if no EIPs created):
 ${join("\n", module.network.nat_gateway_ips)}
 
 All PSE IAM Role ARNs:

--- a/examples/pse/terraform.tfvars
+++ b/examples/pse/terraform.tfvars
@@ -35,7 +35,7 @@
 #pse_group_upgrade_time_in_secs     = "66600"
 #pse_group_override_version_profile = true
 #pse_group_version_profile_id       = "2"
-#pse_is_public                      = "FALSE"
+#pse_is_public                      = false
 #zpa_trusted_network_name           = "Corporate-Network (zscalertwo.net)"   ### this variable is optional. leave commented out if not used  
 
 

--- a/examples/pse/terraform.tfvars
+++ b/examples/pse/terraform.tfvars
@@ -89,12 +89,9 @@
 #pse_count                                       = 2
 
 ## 10. Enable/Disable public IP addresses on Service Edge instances. Default is false. Setting this to true will result in the following: 
-##    Dynamic Public IP address on the Service Edge VM Instance will be enabled; 
+##    Elastic IP address resource creation and assigned per Service Edge instance; 
 ##    No EIP or NAT Gateway resources will be created; 
 ##    The Service Edge Route Table default route next-hop will be set as the IGW
-
-##    Note: Service Edge has no external inbound network dependencies, so the recommendation is to leave this set to false and utilize a NAT Gateway
-##    for internet egress. Only enable this if you are certain you really want it for you environment.
 
 #associate_public_ip_address                    = true
 

--- a/examples/pse/versions.tf
+++ b/examples/pse/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
     zpa = {
       source  = "zscaler/zpa"
-      version = "~> 2.6.0"
+      version = "~> 2.7.0"
     }
   }
 

--- a/examples/pse_asg/README.md
+++ b/examples/pse_asg/README.md
@@ -47,7 +47,7 @@ From pse_asg directory execute:
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.3.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 3.4.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.6.0 |
+| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.7.0 |
 
 ## Providers
 

--- a/examples/pse_asg/terraform.tfvars
+++ b/examples/pse_asg/terraform.tfvars
@@ -35,7 +35,7 @@
 #pse_group_upgrade_time_in_secs     = "66600"
 #pse_group_override_version_profile = true
 #pse_group_version_profile_id       = "2"
-#pse_is_public                      = "FALSE"
+#pse_is_public                      = false
 #zpa_trusted_network_name           = "Corporate-Network (zscalertwo.net)"   ### this variable is optional. leave commented out if not used  
 
 

--- a/examples/pse_asg/versions.tf
+++ b/examples/pse_asg/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
     zpa = {
       source  = "zscaler/zpa"
-      version = "~> 2.6.0"
+      version = "~> 2.7.0"
     }
   }
 

--- a/examples/zspse
+++ b/examples/zspse
@@ -372,7 +372,7 @@ done
 fi
 
 while true; do
-    read -r -p "Should each Service Edge be assigned an automatic public IP address? (yes/no): " public_ip_response
+    read -r -p "Should each Service Edge be assigned a public Elastic IP address? (yes/no): " public_ip_response
 case $public_ip_response in 
 	yes|y ) 
     echo "Service Edges will have public IP addresses associated. No NAT Gateway is required/created..."

--- a/examples/zspse
+++ b/examples/zspse
@@ -377,11 +377,17 @@ while true; do
     if [[ "$dtype" == *"asg"* ]]; then
     read -r -p "Should each Service Edge be assigned an automatic public IP address? (yes/no): " public_ip_response
     else
-    read -r -p "Should each Service Edge be assigned a public Elastic IP address? (yes/no): " public_ip_response
+    read -r -p "Will these Service Edges be used for Public Remote Access? yes/no? (yes/no): " public_ip_response
     fi
 case $public_ip_response in 
 	yes|y ) 
-    echo "Service Edges will have public IP addresses associated. No NAT Gateway is required/created..."
+    if [[ "$dtype" == *"asg"* ]]; then
+    echo "AWS Launch Templates only support dynamic auto public IP assignment..."
+    echo "For Public Remote Access deployments, it is advised to manually create and assign EIPs to any Service Edges launched" 
+    else
+    echo "Service Edges will have static public EIP addresses associated. No NAT Gateway is required/created..."
+    echo "Post deployment, you will need to add the corresponding IPs to each Service Edge 'Public IPs' field in the ZPA Portal"
+    fi
     echo "export TF_VAR_associate_public_ip_address=true" >> .zspserc
     echo "export TF_VAR_pse_is_public=true" >> .zspserc
     associate_public_ip_address=true

--- a/examples/zspse
+++ b/examples/zspse
@@ -371,8 +371,14 @@ fi
 done
 fi
 
+
+
 while true; do
+    if [[ "$dtype" == *"asg"* ]]; then
+    read -r -p "Should each Service Edge be assigned an automatic public IP address? (yes/no): " public_ip_response
+    else
     read -r -p "Should each Service Edge be assigned a public Elastic IP address? (yes/no): " public_ip_response
+    fi
 case $public_ip_response in 
 	yes|y ) 
     echo "Service Edges will have public IP addresses associated. No NAT Gateway is required/created..."
@@ -389,6 +395,7 @@ case $public_ip_response in
 	* ) echo "invalid response. Please enter yes or no";;
     esac
 done
+
 
 psevm_instance_type_default=m5.large
 while true; do

--- a/examples/zspse
+++ b/examples/zspse
@@ -382,7 +382,8 @@ while true; do
 case $public_ip_response in 
 	yes|y ) 
     echo "Service Edges will have public IP addresses associated. No NAT Gateway is required/created..."
-    echo "export TF_VAR_associate_public_ip_address=true" >> .zspserc 
+    echo "export TF_VAR_associate_public_ip_address=true" >> .zspserc
+    echo "export TF_VAR_pse_is_public=true" >> .zspserc
     associate_public_ip_address=true
     break
     ;;

--- a/modules/terraform-zpa-provisioning-key/README.md
+++ b/modules/terraform-zpa-provisioning-key/README.md
@@ -10,13 +10,13 @@ There is a "BYO" option where you can conditionally create new or reference an e
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.6.0 |
+| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | ~> 2.6.0 |
+| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | ~> 2.7.0 |
 
 ## Modules
 

--- a/modules/terraform-zpa-provisioning-key/versions.tf
+++ b/modules/terraform-zpa-provisioning-key/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     zpa = {
       source  = "zscaler/zpa"
-      version = "~> 2.6.0"
+      version = "~> 2.7.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zpa-service-edge-group/README.md
+++ b/modules/terraform-zpa-service-edge-group/README.md
@@ -8,13 +8,13 @@ This module provides the resources necessary to create a new ZPA Service Edge Gr
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.7, < 2.0.0 |
-| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.6.0 |
+| <a name="requirement_zpa"></a> [zpa](#requirement\_zpa) | ~> 2.7.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | ~> 2.6.0 |
+| <a name="provider_zpa"></a> [zpa](#provider\_zpa) | ~> 2.7.0 |
 
 ## Modules
 

--- a/modules/terraform-zpa-service-edge-group/versions.tf
+++ b/modules/terraform-zpa-service-edge-group/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     zpa = {
       source  = "zscaler/zpa"
-      version = "~> 2.6.0"
+      version = "~> 2.7.0"
     }
   }
   required_version = ">= 0.13.7, < 2.0.0"

--- a/modules/terraform-zspse-network-aws/outputs.tf
+++ b/modules/terraform-zspse-network-aws/outputs.tf
@@ -1,6 +1,6 @@
 output "vpc_id" {
   description = "VPC ID Selected"
-  value       = data.aws_vpc.vpc_selected.id
+  value       = try(data.aws_vpc.vpc_selected[0].id, aws_vpc.vpc[0].id)
 }
 
 output "pse_subnet_ids" {

--- a/modules/terraform-zspse-psevm-aws/README.md
+++ b/modules/terraform-zspse-psevm-aws/README.md
@@ -56,7 +56,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_availability_zone"></a> [availability\_zone](#output\_availability\_zone) | Instance Availability Zone |
+| <a name="output_eip_id"></a> [eip\_id](#output\_eip\_id) | Contains the EIP allocation ID |
+| <a name="output_eip_public_ip"></a> [eip\_public\_ip](#output\_eip\_public\_ip) | Instance Elastic Public IP |
 | <a name="output_id"></a> [id](#output\_id) | Instance ID |
 | <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Instance Private IP Address |
-| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | Instance Public IP |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/terraform-zspse-psevm-aws/README.md
+++ b/modules/terraform-zspse-psevm-aws/README.md
@@ -26,6 +26,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_eip.pse_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_instance.pse_vm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_ebs_default_kms_key.current_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_default_kms_key) | data source |
 | [aws_kms_alias.current_kms_arn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias) | data source |

--- a/modules/terraform-zspse-psevm-aws/main.tf
+++ b/modules/terraform-zspse-psevm-aws/main.tf
@@ -18,15 +18,14 @@ data "aws_kms_alias" "current_kms_arn" {
 # Create Service Edge VM
 ################################################################################
 resource "aws_instance" "pse_vm" {
-  count                       = var.pse_count
-  ami                         = element(var.ami_id, count.index)
-  instance_type               = var.psevm_instance_type
-  iam_instance_profile        = element(var.iam_instance_profile, count.index)
-  vpc_security_group_ids      = [element(var.security_group_id, count.index)]
-  subnet_id                   = element(var.pse_subnet_ids, count.index)
-  key_name                    = var.instance_key
-  associate_public_ip_address = var.associate_public_ip_address
-  user_data                   = base64encode(var.user_data)
+  count                  = var.pse_count
+  ami                    = element(var.ami_id, count.index)
+  instance_type          = var.psevm_instance_type
+  iam_instance_profile   = element(var.iam_instance_profile, count.index)
+  vpc_security_group_ids = [element(var.security_group_id, count.index)]
+  subnet_id              = element(var.pse_subnet_ids, count.index)
+  key_name               = var.instance_key
+  user_data              = base64encode(var.user_data)
 
   ebs_optimized = true
 
@@ -48,4 +47,11 @@ resource "aws_instance" "pse_vm" {
   tags = merge(var.global_tags,
     { Name = "${var.name_prefix}-pse-vm-${count.index + 1}-${var.resource_tag}" }
   )
+}
+
+
+resource "aws_eip" "pse_eip" {
+  count    = var.associate_public_ip_address ? var.pse_count : 0
+  instance = aws_instance.pse_vm[count.index].id
+  vpc      = true
 }

--- a/modules/terraform-zspse-psevm-aws/main.tf
+++ b/modules/terraform-zspse-psevm-aws/main.tf
@@ -47,6 +47,12 @@ resource "aws_instance" "pse_vm" {
   tags = merge(var.global_tags,
     { Name = "${var.name_prefix}-pse-vm-${count.index + 1}-${var.resource_tag}" }
   )
+
+  lifecycle {
+    ignore_changes = [
+      root_block_device[0].kms_key_id
+    ]
+  }
 }
 
 
@@ -54,4 +60,8 @@ resource "aws_eip" "pse_eip" {
   count    = var.associate_public_ip_address ? var.pse_count : 0
   instance = aws_instance.pse_vm[count.index].id
   vpc      = true
+
+  tags = merge(var.global_tags,
+    { Name = "${var.name_prefix}-eip-psevm-${count.index + 1}-${var.resource_tag}" }
+  )
 }

--- a/modules/terraform-zspse-psevm-aws/outputs.tf
+++ b/modules/terraform-zspse-psevm-aws/outputs.tf
@@ -15,10 +15,10 @@ output "id" {
 
 output "eip_public_ip" {
   description = "Instance Elastic Public IP"
-  value       = var.associate_public_ip_address ? aws_eip.pse_eip[*].public_ip : null
+  value       = var.associate_public_ip_address ? aws_eip.pse_eip[*].public_ip : [""]
 }
 
 output "eip_id" {
   description = "Contains the EIP allocation ID"
-  value       = var.associate_public_ip_address ? aws_eip.pse_eip[*].id : null
+  value       = var.associate_public_ip_address ? aws_eip.pse_eip[*].id : [""]
 }

--- a/modules/terraform-zspse-psevm-aws/outputs.tf
+++ b/modules/terraform-zspse-psevm-aws/outputs.tf
@@ -13,7 +13,12 @@ output "id" {
   value       = aws_instance.pse_vm[*].id
 }
 
-output "public_ip" {
-  description = "Instance Public IP"
-  value       = aws_instance.pse_vm[*].public_ip
+output "eip_public_ip" {
+  description = "Instance Elastic Public IP"
+  value       = var.associate_public_ip_address ? aws_eip.pse_eip[*].public_ip : null
+}
+
+output "eip_id" {
+  description = "Contains the EIP allocation ID"
+  value       = var.associate_public_ip_address ? aws_eip.pse_eip[*].id : null
 }

--- a/modules/terraform-zspse-sg-aws/main.tf
+++ b/modules/terraform-zspse-sg-aws/main.tf
@@ -25,12 +25,16 @@ resource "aws_security_group" "pse_sg" {
   tags = merge(var.global_tags,
     { Name = "${var.name_prefix}-pse-${count.index + 1}-sg-${var.resource_tag}" }
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Or use existing Security Group ID
 data "aws_security_group" "pse_sg_selected" {
-  count = var.byo_security_group == false ? length(aws_security_group.pse_sg[*].id) : length(var.byo_security_group_id)
-  id    = var.byo_security_group == false ? element(aws_security_group.pse_sg[*].id, count.index) : element(var.byo_security_group_id, count.index)
+  count = var.byo_security_group ? length(var.byo_security_group_id) : 0
+  id    = element(var.byo_security_group_id, count.index)
 }
 
 

--- a/modules/terraform-zspse-sg-aws/outputs.tf
+++ b/modules/terraform-zspse-sg-aws/outputs.tf
@@ -1,9 +1,9 @@
 output "pse_security_group_id" {
   description = "Service Edge Security Group ID"
-  value       = data.aws_security_group.pse_sg_selected[*].id
+  value       = var.byo_security_group ? data.aws_security_group.pse_sg_selected[*].id : aws_security_group.pse_sg[*].id
 }
 
 output "pse_security_group_arn" {
   description = "Service Edge Security Group ARN"
-  value       = data.aws_security_group.pse_sg_selected[*].arn
+  value       = var.byo_security_group ? data.aws_security_group.pse_sg_selected[*].arn : aws_security_group.pse_sg[*].arn
 }


### PR DESCRIPTION
- when setting variable associate_public_ip_address to true for terraform-zspse-psevm-aws, terraform will now create dedicated elastic IP resources and associate with each instance
- autoscaled deployments do not have the ability to set via launch template so they will still receive only dynamic public IPs